### PR TITLE
Remove duplicated buildpack

### DIFF
--- a/app.json
+++ b/app.json
@@ -7,7 +7,6 @@
     "go"
   ],
   "buildpacks":[
-    {"url":"https://github.com/heroku/heroku-buildpack-addon-wait.git"},
     {"url":"heroku/go"}
   ],
   "website": "http://github.com/heroku-examples/go_queue_example",


### PR DESCRIPTION
https://github.com/heroku/heroku-buildpack-addon-wait
>This buildpack is no longer required and is unsupported as its functionality has been built directly into the Heroku app-setups API.